### PR TITLE
articleのnewとeditにリアルタイムマークダウンを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'dotenv-rails'
 
 gem 'seed-fu', '~> 2.3'
 
+gem 'jquery-turbolinks'
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,10 @@ gem 'redcarpet'
 
 gem 'coderay'
 
+gem 'marked-rails'
+
+gem 'highlight', :require => 'simplabs/highlight'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'coderay'
 
 gem 'marked-rails'
 
-gem 'highlight', :require => 'simplabs/highlight'
+gem 'highlight', require: 'simplabs/highlight'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       sexp_processor (~> 4.8)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    highlight (2.0.0)
     i18n (0.8.0)
     ice_nine (0.11.2)
     jbuilder (2.6.1)
@@ -111,6 +112,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    marked-rails (0.3.2.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -247,9 +249,11 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   devise
   dotenv-rails
+  highlight
   jbuilder (~> 2.0)
   jquery-rails
   jquery-turbolinks
+  marked-rails
   mysql2 (~> 0.3.20)
   pry
   rails (= 4.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
-    flog (4.6.0)
+    flog (4.6.1)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
@@ -101,6 +101,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.6)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -246,6 +249,7 @@ DEPENDENCIES
   dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   mysql2 (~> 0.3.20)
   pry
   rails (= 4.2.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,5 @@
 //
 // = require jquery
 // = require jquery_ujs
+//= require jquery.turbolinks
 //= require turbolinks
-//= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,4 @@
 // = require jquery_ujs
 //= require jquery.turbolinks
 //= require turbolinks
+//= require marked

--- a/app/assets/javascripts/articles/preview.js.erb
+++ b/app/assets/javascripts/articles/preview.js.erb
@@ -1,0 +1,7 @@
+$(function(){
+  $("#preview--button").on("click", function() {
+    var body = $("#article_body").val();
+    var markdowned_body = markdown(body);
+    $("#preview--container").html(`<div>${markdowned_body}</div>`);
+  });
+});

--- a/app/assets/javascripts/articles/preview.js.erb
+++ b/app/assets/javascripts/articles/preview.js.erb
@@ -1,7 +1,14 @@
 $(function(){
-  $("#preview--button").on("click", function() {
-    var body = $("#article_body").val();
-    var markdowned_body = markdown(body);
-    $("#preview--container").html(`<div>${markdowned_body}</div>`);
+  marked.setOptions({
+    langPrefix: '',
+    sanitize: true,
+  });
+  $("#article_body").keyup(function() {
+    var src = $(this).val();
+    var preview = marked(src);
+    $("#preview--container").html(`<div>${preview}</div>`);
+    $('pre code').each(function(i, e) {
+      hljs.highlightBlock(e, e.className);
+    });
   });
 });

--- a/app/views/articles/_preview.html.erb
+++ b/app/views/articles/_preview.html.erb
@@ -1,3 +1,0 @@
-<% if params[:preview_button] %>
-  <%= markdown(article.body) %>
-<% end %>

--- a/app/views/articles/_preview.html.erb
+++ b/app/views/articles/_preview.html.erb
@@ -1,0 +1,3 @@
+<% if params[:preview_button] %>
+  <%= markdown(article.body) %>
+<% end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -14,8 +14,6 @@
   <%= f.submit "送信" %>
 <% end %>
 
-<button id='preview--button'>Previewを表示する</button>
-
 <div id='preview--container'>
   <!-- ここにjsでpreview表示する -->
 </div>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'articles/preview' %>
 <h1>Articles#edit</h1>
 <%= form_for @article do |f| %>
    <div>
@@ -12,4 +13,11 @@
    </div>
   <%= f.submit "送信" %>
 <% end %>
+
+<button id='preview--button'>Previewを表示する</button>
+
+<div id='preview--container'>
+  <!-- ここにjsでpreview表示する -->
+</div>
+
 <p>Find me in app/views/articles/edit.html.erb</p>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'articles/preview' %>
 <% if @group.id == MASTER_GROUP_ID %>
   <h1>全体に投稿</h1>
 <% else %>
@@ -17,9 +18,8 @@
     </div>
     <%= f.hidden_field :group_id, value: @group.id %>
     <%= f.submit "送信" %>
-    <%= f.submit_tag 'Preview表示', :name => 'preview_button' %>
   <% end %>
 
-  <%= render partial: 'preview', { article: @article }%>
+  <button id='preview--button'>Previewを表示する</button>
 
 <p>Find me in app/views/articles/new.html.erb</p>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -20,6 +20,8 @@
     <%= f.submit "送信" %>
   <% end %>
 
-  <button id='preview--button'>Previewを表示する</button>
+  <div id='preview--container'>
+    <!-- ここにjsでpreview表示する -->
+  </div>
 
 <p>Find me in app/views/articles/new.html.erb</p>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -17,6 +17,9 @@
     </div>
     <%= f.hidden_field :group_id, value: @group.id %>
     <%= f.submit "送信" %>
+    <%= f.submit_tag 'Preview表示', :name => 'preview_button' %>
   <% end %>
+
+  <%= render partial: 'preview', { article: @article }%>
 
 <p>Find me in app/views/articles/new.html.erb</p>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+Rails.application.config.assets.precompile +=  %w( *.js )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
 
-Rails.application.config.assets.precompile +=  %w( *.js )
+Rails.application.config.assets.precompile += %w(*.js)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
   match 'tags/:tag', to: 'articles#index', as: :tag, via: [:get, :post]
   get 'tags', to: 'tags#index'
 
+  post 'api_markdown' => 'articles#api_markdown'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/public/stylesheets/highlight.css
+++ b/public/stylesheets/highlight.css
@@ -1,0 +1,59 @@
+.c { color: #408080; font-style: italic }  /* Comment */
+.err { border: 1px solid #FF0000 }         /* Error */
+.k { color: #008000; font-weight: bold }   /* Keyword */
+.o { color: #666666 }                      /* Operator */
+.cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.cp { color: #BC7A00 }                     /* Comment.Preproc */
+.c1 { color: #408080; font-style: italic } /* Comment.Single */
+.cs { color: #408080; font-style: italic } /* Comment.Special */
+.gd { color: #A00000 }                     /* Generic.Deleted */
+.ge { font-style: italic }                 /* Generic.Emph */
+.gr { color: #FF0000 }                     /* Generic.Error */
+.gh { color: #000080; font-weight: bold }  /* Generic.Heading */
+.gi { color: #00A000 }                     /* Generic.Inserted */
+.go { color: #808080 }                     /* Generic.Output */
+.gp { color: #000080; font-weight: bold }  /* Generic.Prompt */
+.gs { font-weight: bold }                  /* Generic.Strong */
+.gu { color: #800080; font-weight: bold }  /* Generic.Subheading */
+.gt { color: #0040D0 }                     /* Generic.Traceback */
+.kc { color: #008000; font-weight: bold }  /* Keyword.Constant */
+.kd { color: #008000; font-weight: bold }  /* Keyword.Declaration */
+.kp { color: #008000 }                     /* Keyword.Pseudo */
+.kr { color: #008000; font-weight: bold }  /* Keyword.Reserved */
+.kt { color: #B00040 }                     /* Keyword.Type */
+.m { color: #666666 }                      /* Literal.Number */
+.s { color: #BA2121 }                      /* Literal.String */
+.na { color: #7D9029 }                     /* Name.Attribute */
+.nb { color: #008000 }                     /* Name.Builtin */
+.nc { color: #0000FF; font-weight: bold }  /* Name.Class */
+.no { color: #880000 }                     /* Name.Constant */
+.nd { color: #AA22FF }                     /* Name.Decorator */
+.ni { color: #999999; font-weight: bold }  /* Name.Entity */
+.ne { color: #D2413A; font-weight: bold }  /* Name.Exception */
+.nf { color: #0000FF }                     /* Name.Function */
+.nl { color: #A0A000 }                     /* Name.Label */
+.nn { color: #0000FF; font-weight: bold }  /* Name.Namespace */
+.nt { color: #008000; font-weight: bold }  /* Name.Tag */
+.nv { color: #19177C }                     /* Name.Variable */
+.ow { color: #AA22FF; font-weight: bold }  /* Operator.Word */
+.w { color: #bbbbbb }                      /* Text.Whitespace */
+.mf { color: #666666 }                     /* Literal.Number.Float */
+.mh { color: #666666 }                     /* Literal.Number.Hex */
+.mi { color: #666666 }                     /* Literal.Number.Integer */
+.mo { color: #666666 }                     /* Literal.Number.Oct */
+.sb { color: #BA2121 }                     /* Literal.String.Backtick */
+.sc { color: #BA2121 }                     /* Literal.String.Char */
+.sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.s2 { color: #BA2121 }                     /* Literal.String.Double */
+.se { color: #BB6622; font-weight: bold }  /* Literal.String.Escape */
+.sh { color: #BA2121 }                     /* Literal.String.Heredoc */
+.si { color: #BB6688; font-weight: bold }  /* Literal.String.Interpol */
+.sx { color: #008000 }                     /* Literal.String.Other */
+.sr { color: #BB6688 }                     /* Literal.String.Regex */
+.s1 { color: #BA2121 }                     /* Literal.String.Single */
+.ss { color: #19177C }                     /* Literal.String.Symbol */
+.bp { color: #008000 }                     /* Name.Builtin.Pseudo */
+.vc { color: #19177C }                     /* Name.Variable.Class */
+.vg { color: #19177C }                     /* Name.Variable.Global */
+.vi { color: #19177C }                     /* Name.Variable.Instance */
+.il { color: #666666 }                     /* Literal.Number.Integer.Long */


### PR DESCRIPTION
# 目的

markdownが機能しているかを記入時にリアルタイムで確認できるように変更

# やったこと
- markedのgemをインストール
- markdownを適応した結果を表示する部分テンプレート追加
- articleのnewとeditのフォームの内容をjsで取得
- markedでmarkdownを反映した値をuserが何か書き込むたびに更新してrendering