### PR TITLE
メール認証を中心にしたセキュリティ&バリデーション強化

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,9 +5,10 @@ class Article < ActiveRecord::Base
   has_many :comments, dependent: :destroy
   has_many :stocks, dependent: :destroy
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
   validates :body, presence: true
   validates :user_id, presence: true
+  validates :group_id, presence: true
 
   # グループとの関連付けに関するscope
   scope :available_to, ->(user) { where(group_id: user.groups.map(&:id)) }

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,4 +1,7 @@
 class ArticleLike < ActiveRecord::Base
   belongs_to :article, counter_cache: :likes_count
   belongs_to :user
+
+  validates :user_id
+  validates :article_id, presence: true, uniqueness: { scope: [:user_id] }
 end

--- a/app/models/comment_like.rb
+++ b/app/models/comment_like.rb
@@ -1,4 +1,7 @@
 class CommentLike < ActiveRecord::Base
   belongs_to :comment, counter_cache: :likes_count
   belongs_to :user
+
+  validates :user_id, presence: true
+  validates :group_id, presence: true, uniqueness: { scope: [:user_id] }
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,6 +6,8 @@ class Group < ActiveRecord::Base
 
   validates :name, presence: true
   validates :body, presence: true
+  validates :manager_id, presence: true
+  validates :private
 
   def relation_with_user(user)
     group_users.find_by(user_id: user.id)

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -3,5 +3,5 @@ class GroupUser < ActiveRecord::Base
   belongs_to :group
 
   validates :user_id, presence: true
-  validates :group_id, presence: true
+  validates :group_id, presence: true, uniqueness: { scope: [:user_id] }
 end

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -1,3 +1,3 @@
 class Manager < User
-  has_one :group, dependent: :destroy
+  has_one :group
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -3,5 +3,5 @@ class Stock < ActiveRecord::Base
   belongs_to :user
 
   validates :user_id, presence: true
-  validates :article_id, presence: true
+  validates :article_id, presence: true, uniqueness: { scope: [:user_id] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,13 +6,13 @@ class User < ActiveRecord::Base
          :confirmable
 
   validates :username, presence: true, uniqueness: true
-  validates_format_of :slack_name,
-                      presence: true,
+  validates :slack_name,
+            format: { presence: true,
                       with: /\@/,
-                      message: 'should start with @'
-  validates_format_of :email,
-                      with: /\@finc\.com/,
-                      message: 'should be from finc.com'
+                      message: 'should start with @' }
+  validates :email,
+            format: { with: /\@finc\.com/,
+                      message: 'should be from finc.com' }
 
   scope :searched_by_name, ->(keyword) { where('username LIKE(?)', "%#{keyword}%") }
   scope :group_manager, ->(group_manager_id) { find_by('id = ?', group_manager_id) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,15 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
 
+  validates :username, presence: true, uniqueness: true
+  validates_format_of :slack_name,
+                      presence: true,
+                      with: /\@/,
+                      message: 'should start with @'
+  validates_format_of :email,
+                      with: /\@finc\.com/,
+                      message: 'should be from finc.com'
+
   scope :searched_by_name, ->(keyword) { where('username LIKE(?)', "%#{keyword}%") }
   scope :group_manager, ->(group_manager_id) { find_by('id = ?', group_manager_id) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable,
+         :confirmable
 
   scope :searched_by_name, ->(keyword) { where('username LIKE(?)', "%#{keyword}%") }
   scope :group_manager, ->(group_manager_id) { find_by('id = ?', group_manager_id) }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,13 +9,13 @@
   </div>
 
   <div class="field">
-    <%= f.label :slack_name %><br />
-    <%= f.text_field :slack_name %>
+    <span>Slack name (it has to be started with '@')</span><br>
+    <%= f.text_field :slack_name, value: '@' %>
   </div>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email %>
+    <span>Email (it has to end with '@finc.com')</span><br>
+    <%= f.email_field :email, value: '@finc.com' %>
   </div>
 
   <div class="field">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,12 +10,12 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    :address => "smtp.gmail.com",
-    :port => 587,
-    :user_name => ENV['SMTP_EMAIL'],
-    :password => ENV['SMTP_PASSWORD'],
-    :authentication => :plain,
-    :enable_starttls_auto => true
+    address: ENV['SMTP_ADDRESS'],
+    port: ENV['SMTP_PORT'],
+    user_name: ENV['SMTP_EMAIL'],
+    password: ENV['SMTP_PASSWORD'],
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   # Do not eager load code on boot.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,17 @@ Rails.application.configure do
   config.cache_classes = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :user_name => ENV['SMTP_EMAIL'],
+    :password => ENV['SMTP_PASSWORD'],
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
+
   # Do not eager load code on boot.
   config.eager_load = false
 
@@ -15,7 +26,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -133,7 +133,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]


### PR DESCRIPTION
# 目的
貯めて行った知識のログを外部の人に見られないようにすると共に、予期しない挙動が起こるのを防ぐ

# やったこと
- deviseの認証メール機能を有効に(今はqiita_team_test@gmail.comからメールが来るようにSMTPを設定)
- userのaddressは'@finc.com'を含まないといけないようにvalidationを設定
- userのslack-nameは@を含まないといけないようにvalidationを設定
- いいね / stock のは同ユーザーにつき一回しか押せないようにvalidationを設定